### PR TITLE
Version 1.4.1

### DIFF
--- a/app/localdb.py
+++ b/app/localdb.py
@@ -11,7 +11,7 @@ def createdb(dbname):
 class cplocaldb(object):
     def __init__(self, database):
         self.database = database
-        self.dbconn = sqlite3.connect(database)
+        self.dbconn = sqlite3.connect(database, check_same_thread=False)
         self.dbconn.row_factory = sqlite3.Row
         self.cursor = self.dbconn.cursor()
 


### PR DESCRIPTION
Bug Fix for sqlite3 connection being used again in separate thread. There are no threaded calls, should be safe from db locks. Will look to create session per endpoint in a future release to remote this need.